### PR TITLE
Ability to build for target platform using docker buildx via options

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,19 @@ Simply run `yarn build` to build using defaults. Run `yarn build -h` to view hel
 
 #### Options:
 ```
--i, --info                             Output the current CLI version number
--t, --type <type>                      Which images to build (all, strapi, base) (default: "all")
--p, --push                             Push the image(s) after creating
--v, --strapi-version <strapiVersion>   Strapi version to build (default: "latest")
--n, --node-versions <nodeVersions...>  Node (default: ["16"])
--h, --help
+-i, --info                              Output the current CLI version number
+-t, --type <type>                       Which images to build (all, strapi, base) (default: "all")
+-p, --push                              Push the image(s) after creating
+-v, --strapi-version <strapiVersion>    Strapi version to build (default: "latest")
+-n, --node-versions <nodeVersions...>   Node (default: ["16"])
+-b, --buildx-platform <buildxPlatform>  IF exists THEN docker buildx build --platform <buildxPlatform> is used. ELSE docker build...
+-h, --help                              display help for command
+```
+
+#### Examples:
+- Buildx platform
+
+Create an image for a target architecture and operating system using `docker buildx build`. When not set, the image will build using the default `docker build...`
+```
+yarn run build -b linux/amd64
 ```

--- a/bin/build.mjs
+++ b/bin/build.mjs
@@ -18,6 +18,7 @@ program
   .option('-p, --push', 'Push the image(s) after creating')
   .option('-v, --strapi-version <strapiVersion>', 'Strapi version to build', 'latest')
   .option('-n, --node-versions <nodeVersions...>', 'Node', [LATEST_NODE_VERSION])
+  .option('-b, --buildx-platform <buildxPlatform>', 'IF exists THEN docker buildx build --platform <buildxPlatform> is used. ELSE docker build...')
   .action((options) => {
     run(options).catch(error => {
       console.error(error);
@@ -27,22 +28,22 @@ program
 
 program.parse();
 
-async function run({ type, push, strapiVersion, nodeVersions }) {
+async function run({ type, push, strapiVersion, nodeVersions, buildxPlatform }) {
   switch (type) {
     case 'base': {
-      const images = await buildBaseImages({ shouldPush: push, nodeVersions });
+      const images = await buildBaseImages({ shouldPush: push, nodeVersions, buildxPlatform });
       logImages(images);
       break;
     }
     case 'strapi': {
-      const images = await buildStrapiImages({ version: strapiVersion, shouldPush: push, nodeVersions });
+      const images = await buildStrapiImages({ version: strapiVersion, shouldPush: push, nodeVersions, buildxPlatform });
       logImages(images);
       break;
     }
     case 'all':
     default: {
-      const baseImages = await buildBaseImages({ shouldPush: push, nodeVersions });
-      const strapiImages = await buildStrapiImages({ version: strapiVersion, shouldPush: push, nodeVersions });
+      const baseImages = await buildBaseImages({ shouldPush: push, nodeVersions, buildxPlatform });
+      const strapiImages = await buildStrapiImages({ version: strapiVersion, shouldPush: push, nodeVersions, buildxPlatform });
       logImages([...baseImages, ...strapiImages]);
       break;
     }

--- a/bin/utils.mjs
+++ b/bin/utils.mjs
@@ -16,3 +16,13 @@ export function execDocker(args) {
     stdio: 'inherit',
   });
 }
+
+export function getBuildXArgs(buildxPlatform) {
+  const buildXCmd = !buildxPlatform ? [] : [ 'buildx' ];
+
+  const buildXArgs = !buildxPlatform ? [] : [
+    '--platform',
+    buildxPlatform
+  ]
+  return { buildXCmd, buildXArgs }
+}


### PR DESCRIPTION
Hi,

In addition to the other pull request for overriding image names, I also needed this. Again, I hope it may be useful for others.

I haven't tested for multiple platforms, but theoretically it should work. However, for now, I've just added the example of 1 target platform to the README as I know this works for me.